### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can sign up for a [free trial](https://my.joyentcloud.com/landing/signup/701
 
 Then, if you have Mac OS X:
 
-1. Install node, npm, node-manta and smartdc tools using the (Mac OS X Installer)[https://us-east.manta.joyent.com/manta/public/sdks/joyent-node-latest.pkg].
+1. Install node, npm, node-manta and smartdc tools using the [Mac OS X Installer](https://us-east.manta.joyent.com/manta/public/sdks/joyent-node-latest.pkg).
 1. Install the jsontool `sudo npm install jsontool -g`
 1. Install [git](http://git-scm.com)
 


### PR DESCRIPTION
Some cleanup in the readme.md file.

Added the ssh-keygen command to the config.  Gave credits to Mojang.  Mentioned that we don't make any money off of this directly.  Tested on Ubuntu 13.10.  Mentioned that git is needed, and ssh-agent needs to be running.
