### PR TITLE
Switch to https:// scheme for git clone

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,4 +2,4 @@
 
 /opt/local/bin/pkgin -y in scmgit-base
 cd /opt
-/opt/local/bin/git clone git@github.com:joyent/minecrab.git
+/opt/local/bin/git clone https://github.com/joyent/minecrab.git


### PR DESCRIPTION
Suggested by Nick in https://github.com/joyent/minecrab/issues/50 and Philip in #47 
